### PR TITLE
Check memoized template from own properties

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -127,6 +127,16 @@
         </style>
       </template>
     </dom-module>
+
+    <dom-module id="baz-styles" theme-for="test-baz">
+      <template>
+        <style>
+          [part="text"] {
+            width: 100px;
+          }
+        </style>
+      </template>
+    </dom-module>
   </div>
 
   <test-fixture id="default">
@@ -176,6 +186,10 @@
 
       it('should fall back to default styles', function() {
         expect(window.getComputedStyle(components[3].$.text).color).to.equal('rgb(255, 0, 0)');
+      });
+
+      it('should work with themable parent', function() {
+        expect(window.getComputedStyle(components[2].$.text).width).to.equal('100px');
       });
 
     });

--- a/vaadin-themable-mixin.html
+++ b/vaadin-themable-mixin.html
@@ -6,13 +6,9 @@
    */
   Vaadin.ThemableMixin = superClass => class VaadinThemableMixin extends superClass {
 
-    static constructor() {
-      this._memoizedTemplate = undefined;
-    }
-
     static get template() {
-      if (super.template && !this._memoizedTemplate) {
-        this._memoizedTemplate = super.template.cloneNode(true);
+      if (super.template && !this.hasOwnProperty('_memoizedThemableMixinTemplate')) {
+        this._memoizedThemableMixinTemplate = super.template.cloneNode(true);
 
         const modules = Polymer.DomModule.prototype.modules;
         let hasThemes = false;
@@ -37,13 +33,13 @@
           this.includeStyle(defaultModuleName);
         }
       }
-      return this._memoizedTemplate;
+      return this._memoizedThemableMixinTemplate;
     }
 
     static includeStyle(moduleName) {
       const styleEl = document.createElement('style');
       styleEl.setAttribute('include', moduleName);
-      this._memoizedTemplate.content.appendChild(styleEl);
+      this._memoizedThemableMixinTemplate.content.appendChild(styleEl);
     }
 
   };


### PR DESCRIPTION
Fixes an issue with theming a child element with themable parent element.

1. The existence `_memoizedTemplate ` was checked directly with `this._memoizedTemplate` which returned truthy if parent already has a `_memoizedTemplate` defined. Changed this so that the property is checked from own properties only.

2. Renamed the property to avoid possible collisions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-themable-mixin/10)
<!-- Reviewable:end -->
