### PR TITLE
Remove observedAttributes getter from ThemePropertyMixin

### DIFF
--- a/vaadin-theme-property-mixin.html
+++ b/vaadin-theme-property-mixin.html
@@ -25,11 +25,6 @@
     }
 
     /** @protected */
-    static get observedAttributes() {
-      return ['theme'];
-    }
-
-    /** @protected */
     attributeChangedCallback(name, oldValue, newValue) {
       super.attributeChangedCallback(name, oldValue, newValue);
 


### PR DESCRIPTION
Turns out, Polymer maintains the observedAttributes list itself. Overriding that is harmful and pointless.

Without this change vaadin/vaadin-combo-box#712 has many failures in non-related tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-themable-mixin/33)
<!-- Reviewable:end -->
