### PR TITLE
Make themable mixin extend the theme property mixin

### DIFF
--- a/vaadin-themable-mixin.html
+++ b/vaadin-themable-mixin.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/lib/elements/dom-module.html">
+<link rel="import" href="vaadin-theme-property-mixin.html">
 
 <script>
   /**
@@ -10,7 +11,7 @@
    * @polymerMixin
    * @memberof Vaadin
    */
-  Vaadin.ThemableMixin = superClass => class VaadinThemableMixin extends superClass {
+  Vaadin.ThemableMixin = superClass => class VaadinThemableMixin extends Vaadin.ThemePropertyMixin(superClass) {
 
     /** @protected */
     static finalize() {


### PR DESCRIPTION
Make the themable mixin extend the theme property mixin, so that all themable elements would always have the attribute. This would allow tooling to more easily discover valid attributes for Vaadin elements.

This PR adds the desired functionality, but I need guidance on what types of tests are expected for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-themable-mixin/39)
<!-- Reviewable:end -->
