### PR TITLE
Fix the querySelector using moduleName

### DIFF
--- a/vaadin-themable-mixin.html
+++ b/vaadin-themable-mixin.html
@@ -61,7 +61,7 @@
 
     /** @private */
     static _includeStyle(moduleName, template) {
-      if (template && !template.content.querySelector(`style[include=${moduleName}]`)) {
+      if (template && !template.content.querySelector(`style[include="${moduleName}"]`)) {
         const styleEl = document.createElement('style');
         styleEl.setAttribute('include', moduleName);
         template.content.appendChild(styleEl);


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-themable-mixin/issues/40

Couldn't find a way to produce an isolated test case for this, will have to do it separately. For now it's most important to get this hotfix shipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-themable-mixin/41)
<!-- Reviewable:end -->
