### PR TITLE
Re-export css literal and unsafeCSS from lit-element

### DIFF
--- a/magi-p3-post.json
+++ b/magi-p3-post.json
@@ -7,7 +7,7 @@
   ],
   "to": [
     "\"dependencies\": {\n\"  lit-element\": \"^2.0.0\",",
-    "import '@polymer/polymer/lib/elements/dom-module.js';\nimport { CSSResult } from 'lit-element';\nexport { css, CSSResult, unsafeCSS } from 'lit-element';",
-    "import { registerStyles, css, unsafeCSS, CSSResult } from '../register-styles.js';"
+    "import '@polymer/polymer/lib/elements/dom-module.js';\nimport { CSSResult } from 'lit-element';\nexport { css, unsafeCSS } from 'lit-element';",
+    "import { registerStyles, css, unsafeCSS } from '../register-styles.js';"
   ]
 }

--- a/magi-p3-post.json
+++ b/magi-p3-post.json
@@ -1,0 +1,13 @@
+{
+  "files": ["package.json", "register-styles.js", "test/register-styles.html"],
+  "from": [
+    "\"dependencies\": {",
+    "import '@polymer/polymer/lib/elements/dom-module.js';",
+    "import '../register-styles.js';"
+  ],
+  "to": [
+    "\"dependencies\": {\n\"  lit-element\": \"^2.0.0\",",
+    "import '@polymer/polymer/lib/elements/dom-module.js';\nimport { CSSResult } from 'lit-element';\nexport { css, CSSResult, unsafeCSS } from 'lit-element';",
+    "import { registerStyles, css, unsafeCSS, CSSResult } from '../register-styles.js';"
+  ]
+}

--- a/register-styles.html
+++ b/register-styles.html
@@ -72,6 +72,7 @@
     themeModuleElement.register(themeId);
   };
 
+  /* MAGI REMOVE START */
   /* Template literal tags derived from LitElement */
 
   const constructionToken = {};
@@ -122,5 +123,6 @@
     return new CSSResult(cssText, constructionToken);
   };
 
+  /* MAGI REMOVE END */
 })();
 </script>

--- a/test/register-styles.html
+++ b/test/register-styles.html
@@ -45,6 +45,10 @@
     });
 
     describe('registerStyles', () => {
+      /* MAGI REMOVE START */
+      let registerStyles, css, unsafeCSS;
+      /* MAGI REMOVE END */
+
       let styles;
 
       let testId = 0;
@@ -53,23 +57,28 @@
         return `foo-${testId}-${seed}`;
       }
 
-      before(() => styles = Vaadin.css`
-        :host {
-          color: rgb(255, 0, 0);
-        }
-      `);
+      before(() => {
+        /* MAGI REMOVE START */
+        ({registerStyles, css, unsafeCSS} = window.Vaadin);
+        /* MAGI REMOVE END */
+        styles = css`
+          :host {
+            color: rgb(255, 0, 0);
+          }
+        `;
+      });
 
       beforeEach(() => testId++);
 
       it('should add theme for a component', () => {
-        Vaadin.registerStyles(unique(), styles);
+        registerStyles(unique(), styles);
 
         const instance = defineAndInstantiate(unique());
         expect(window.getComputedStyle(instance).color).to.equal('rgb(255, 0, 0)');
       });
 
       it('should add multiple themes for a component', () => {
-        Vaadin.registerStyles(unique(), [styles, Vaadin.css`:host {
+        registerStyles(unique(), [styles, css`:host {
           background-color: rgb(0, 255, 0);
         }`]);
 
@@ -82,14 +91,14 @@
         const unsafe = `:host {
           color: rgb(255, 0, 0);
         }`;
-        Vaadin.registerStyles(unique(), Vaadin.unsafeCSS(unsafe));
+        registerStyles(unique(), unsafeCSS(unsafe));
 
         const instance = defineAndInstantiate(unique());
         expect(window.getComputedStyle(instance).color).to.equal('rgb(255, 0, 0)');
       });
 
       it('should interpolate numbers in the template literal', () => {
-        Vaadin.registerStyles(unique(), Vaadin.css`:host {
+        registerStyles(unique(), css`:host {
           color: rgb(${255}, 0, 0);
         }`);
 
@@ -99,7 +108,7 @@
 
       it('should throw if strings are interpolated in the literal', () => {
         expect(() => {
-          Vaadin.css`:host {
+          css`:host {
             color: rgb(${'255'}, 0, 0);
           }`;
         }).to.throw(Error);
@@ -119,18 +128,18 @@
       describe('style module support', () => {
 
         it('should add theme for a component and register with specified module id', () => {
-          Vaadin.registerStyles(undefined, Vaadin.css`:host {
+          registerStyles(undefined, css`:host {
             color: rgb(255, 0, 0);
           }`, {moduleId: unique('id')});
 
-          Vaadin.registerStyles(unique('component'), undefined, {include: [unique('id')]});
+          registerStyles(unique('component'), undefined, {include: [unique('id')]});
 
           const instance = defineAndInstantiate(unique('component'));
           expect(window.getComputedStyle(instance).color).to.equal('rgb(255, 0, 0)');
         });
 
         it('should not add a theme-for attribute to the module with id', () => {
-          Vaadin.registerStyles(undefined, Vaadin.css`:host {
+          registerStyles(undefined, css`:host {
             color: rgb(255, 0, 0);
           }`, {moduleId: unique('id')});
 
@@ -143,7 +152,7 @@
           defineAndInstantiate(unique());
           const warn = sinon.stub(console, 'warn');
 
-          Vaadin.registerStyles(unique(), styles);
+          registerStyles(unique(), styles);
 
           expect(warn.called).to.be.true;
           warn.restore();
@@ -151,7 +160,7 @@
 
         it('should not warn about registering the style too late', () => {
           const warn = sinon.stub(console, 'warn');
-          Vaadin.registerStyles(unique(), styles);
+          registerStyles(unique(), styles);
 
           expect(warn.called).to.be.false;
           warn.restore();
@@ -160,7 +169,7 @@
         it('should not warn about registering the style too late 2', () => {
           define(unique());
           const warn = sinon.stub(console, 'warn');
-          Vaadin.registerStyles(unique(), styles);
+          registerStyles(unique(), styles);
 
           expect(warn.called).to.be.false;
           warn.restore();


### PR DESCRIPTION
This PR introduces a direct dependency to `lit-element` and allows to do the following:

```js
import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
import { css } from 'lit-element';

registerStyles(
  'my-element', 
  css`
    /* Styles with "css" / "unsafeCSS" from lit-element */
  `
);
```

The implementation used is adjusted so that in Polymer 3 we don't have own `CSSResult`, `css` and `unsafeCSS`. Instead we import (and re-export) them from `lit-element`.

Without this change, users would start wondering about when should they import `css` from `@vaadin/vaadin-themable-mixin` and when from `lit-element`.

Assuming the public API contracts stay the same, let me consider this an internal change :trollface: 😎 