### PR TITLE
Support CSSResult factory in registerStyles

### DIFF
--- a/magi-p3-post.json
+++ b/magi-p3-post.json
@@ -1,0 +1,11 @@
+{
+  "files": ["package.json", "test/register-styles.html"],
+  "from": [
+    "\"devDependencies\": {",
+    "import { css, registerStyles, unsafeCSS } from '../register-styles.js';"
+  ],
+  "to": [
+    "\"devDependencies\": {\n  \"lit-element\": \"^2.0.0\",",
+    "import { css, registerStyles, unsafeCSS } from '../register-styles.js';\nimport { css as litCss, CSSResult as LitCSSResult } from 'lit-element';"
+  ]
+}

--- a/register-styles.html
+++ b/register-styles.html
@@ -24,13 +24,14 @@
    */
   Vaadin.registerStyles = (themeFor, styles, options) => {
     const themeId = (options && options.moduleId) || `custom-style-module-${moduleIdIndex++}`;
+    const factory = (options && options.factory) || CSSResult;
 
     if (!Array.isArray(styles)) {
       styles = styles ? [styles] : [];
     }
 
     styles.forEach(cssResult => {
-      if (!(cssResult instanceof CSSResult)) {
+      if (!(cssResult instanceof factory)) {
         throw new Error(
           'An item in styles is not of type CSSResult. Use `unsafeCSS` or `css`.');
       }

--- a/test/register-styles.html
+++ b/test/register-styles.html
@@ -105,6 +105,17 @@
         }).to.throw(Error);
       });
 
+      /* MAGI ADD START
+      it('should allow to pass CSSResult factory from lit-element', () => {
+        Vaadin.registerStyles(unique(), litCss`:host {
+          color: rgb(0, 0, 255);
+        }`, {factory: LitCSSResult});
+
+        const instance = defineAndInstantiate(unique());
+        expect(window.getComputedStyle(instance).color).to.equal('rgb(0, 0, 255)');
+      });
+      MAGI ADD END */
+
       // The following tests exists mainly due to the current techincal limitations
       // of Polymer style module based themable-mixin implementation.
       // Once the component theming is based on constructable stylesheets


### PR DESCRIPTION
Connected to #66 

Alternative to #67.

This PR does not introduce direct dependency to `lit-element` and allows to do the following:

```js
import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
import { css, CSSResult } from 'lit-element';

registerStyles(
  'my-element', 
  css`
    /* Styles with "css" / "unsafeCSS" from lit-element */
  `, 
  {factory: CSSResult}
);
```

Compared to #67 the only drawback is having to write `{factory: CSSResult}` explicitly.
At the same time with this approach users have more flexibility.

This is intended to be not a "public feature". We can even restrict it to Polymer 3 only.
Therefore I do not consider it eligible for a minor release.