### PR TITLE
test: remove test for CSSResult as not exported

### DIFF
--- a/test/register-styles.html
+++ b/test/register-styles.html
@@ -105,14 +105,6 @@
         }).to.throw(Error);
       });
 
-      it('should throw if CSSResult is constructed', () => {
-        expect(() => {
-          new CSSResult(`:host {
-            color: rgb(255, 0, 0);
-          }`);
-        }).to.throw(Error);
-      });
-
       // The following tests exists mainly due to the current techincal limitations
       // of Polymer style module based themable-mixin implementation.
       // Once the component theming is based on constructable stylesheets


### PR DESCRIPTION
The test was copy-pasted from `lit-element` which exports `CSSResult`. But we don't export it. 
So effectively this test is just testing that `new undefined` throws. We should remove it.