### PR TITLE
chore: prepare for TS defs generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - node_modules
 
 addons:
-  firefox: "66.0"
+  firefox: latest
   chrome: stable
 
 before_script:

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,6 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "test/**/*"
+  ]
+}

--- a/vaadin-themable-mixin.html
+++ b/vaadin-themable-mixin.html
@@ -32,7 +32,7 @@
       this._includeMatchingThemes(template);
     }
 
-    /** @protected */
+    /** @private */
     static _includeMatchingThemes(template) {
       const domModule = Polymer.DomModule;
       const modules = domModule.prototype.modules;


### PR DESCRIPTION
Fixes #74 

The result of running `magi p3-convert` locally (without auto-generated comments in `.d.ts`):

## Output

```
> @vaadin/vaadin-themable-mixin@1.5.2 generate-typings /Users/sergey/vaadin/vaadin-themable-mixin
> gen-typescript-declarations --outDir . --verify

Loading config from "gen-tsd.json".
Writing type declarations to /Users/sergey/vaadin/vaadin-themable-mixin
Verifying type declarations
Compilation successful
```


## register-styles.d.ts

```ts
import {CSSResult} from 'lit-element';

export {css, unsafeCSS} from 'lit-element';

export {registerStyles};

/**
 * Registers CSS styles for a component type. Make sure to register the styles before
 * the first instance of a component of the type is attached to DOM.
 */
declare function registerStyles(themeFor: String|null, styles: CSSResult|Array<CSSResult|null>|null): void;
```

## vaadin-theme-property-mixin.d.ts

```ts
export {ThemePropertyMixin};

declare function ThemePropertyMixin<T extends new (...args: any[]) => {}>(base: T): T & ThemePropertyMixinConstructor;

interface ThemePropertyMixinConstructor {
  new(...args: any[]): ThemePropertyMixin;
}

export {ThemePropertyMixinConstructor};

interface ThemePropertyMixin {

  /**
   * Helper property with theme attribute value facilitating propagation
   * in shadow DOM.
   *
   * Enables the component implementation to propagate the `theme`
   * attribute value to the subcomponents in Shadow DOM by binding
   * the subcomponent’s "theme" attribute to the `theme` property of
   * the host.
   *
   * **NOTE:** Extending the mixin only provides the property for binding,
   * and does not make the propagation alone.
   *
   * See [Theme Attribute and Subcomponents](https://github.com/vaadin/vaadin-themable-mixin/wiki/5.-Theme-Attribute-and-Subcomponents).
   * page for more information.
   */
  readonly theme: string|null|undefined;
  attributeChangedCallback(name: any, oldValue: any, newValue: any): void;
}
```

## vaadin-themable-mixin.d.ts

```ts
import {DomModule} from '@polymer/polymer/lib/elements/dom-module.js';

import {ThemePropertyMixin} from './vaadin-theme-property-mixin.js';

export {ThemableMixin};

declare function ThemableMixin<T extends new (...args: any[]) => {}>(base: T): T & ThemableMixinConstructor & ThemePropertyMixinConstructor;

import {ThemePropertyMixinConstructor} from './vaadin-theme-property-mixin.js';

interface ThemableMixinConstructor {
  new(...args: any[]): ThemableMixin;
  finalize(): void;
}

export {ThemableMixinConstructor};

interface ThemableMixin extends ThemePropertyMixin {
}
```